### PR TITLE
[FEAT] 푸시 알림 저장 및 열람 기능 추가

### DIFF
--- a/menu/models.py
+++ b/menu/models.py
@@ -11,7 +11,7 @@ class Menu(models.Model):
 
 class Breakfast(models.Model):
     id = models.AutoField(primary_key=True)
-    menu = models.ForeignKey(Menu, on_delete=models.CASCADE, related_name='breakfasts')
+    menu = models.ForeignKey(Menu, on_delete=models.CASCADE, related_name='breakfast')
     name = models.CharField(max_length=512)
 
     def __str__(self):
@@ -20,7 +20,7 @@ class Breakfast(models.Model):
 
 class Lunch(models.Model):
     id = models.AutoField(primary_key=True)
-    menu = models.ForeignKey(Menu, on_delete=models.CASCADE, related_name='lunches')
+    menu = models.ForeignKey(Menu, on_delete=models.CASCADE, related_name='lunch')
     name = models.CharField(max_length=512)
 
     def __str__(self):
@@ -29,7 +29,7 @@ class Lunch(models.Model):
 
 class Dinner(models.Model):
     id = models.AutoField(primary_key=True)
-    menu = models.ForeignKey(Menu, on_delete=models.CASCADE, related_name='dinners')
+    menu = models.ForeignKey(Menu, on_delete=models.CASCADE, related_name='dinner')
     name = models.CharField(max_length=512)
 
     def __str__(self):

--- a/push/containers.py
+++ b/push/containers.py
@@ -11,3 +11,8 @@ class PushContainer(containers.DeclarativeContainer):
         push_repository=push_repository,
         board_repository=board_repository
     )
+    device_service = providers.Factory(
+        PushService,
+        push_repository=push_repository,
+        board_repository=board_repository
+    )

--- a/push/serializers/__init__.py
+++ b/push/serializers/__init__.py
@@ -1,1 +1,1 @@
-from .push_serializers import TokenRequestSerializer
+from .push_serializers import TokenRequestSerializer, PushListResponseSerializer

--- a/push/serializers/__init__.py
+++ b/push/serializers/__init__.py
@@ -1,1 +1,5 @@
-from .push_serializers import TokenRequestSerializer, PushListResponseSerializer
+from .push_serializers import (
+    TokenRequestSerializer,
+    PushListResponseSerializer,
+    PushCheckRequestSerialzier
+)

--- a/push/serializers/push_serializers.py
+++ b/push/serializers/push_serializers.py
@@ -8,6 +8,13 @@ class PushListResponseSerializer(serializers.Serializer):
     title = serializers.CharField()
     body = serializers.CharField()
     pushedAt = serializers.CharField()
+    transformedPushedAt = serializers.CharField()
     boardId = serializers.IntegerField(allow_null=True)
     postId = serializers.IntegerField(allow_null=True)
     isChecked = serializers.BooleanField()
+
+
+class PushCheckRequestSerialzier(serializers.Serializer):
+    memberId = serializers.IntegerField(source='member_id')
+    pushedAt = serializers.CharField(source='pushed_at')
+    

--- a/push/serializers/push_serializers.py
+++ b/push/serializers/push_serializers.py
@@ -2,3 +2,12 @@ from rest_framework import serializers
 
 class TokenRequestSerializer(serializers.Serializer):
     pushToken = serializers.CharField(source='push_token')
+
+class PushListResponseSerializer(serializers.Serializer):
+    memberId = serializers.IntegerField()
+    title = serializers.CharField()
+    body = serializers.CharField()
+    pushedAt = serializers.CharField()
+    boardId = serializers.IntegerField(allow_null=True)
+    postId = serializers.IntegerField(allow_null=True)
+    isChecked = serializers.BooleanField()

--- a/push/services/__init__.py
+++ b/push/services/__init__.py
@@ -1,1 +1,2 @@
 from .push_services import PushService
+from .device_service import DeviceService

--- a/push/services/device_service.py
+++ b/push/services/device_service.py
@@ -1,0 +1,30 @@
+from push.serializers import TokenRequestSerializer
+from push.domains import PushRepository
+from board.repositories import BoardRepository
+from menu.models import Menu
+from push.domains.device import Device
+
+class DeviceService:
+    def __init__(self, push_repository: PushRepository, board_repository: BoardRepository):
+        self._push_repository = push_repository
+        self._board_repository = board_repository
+
+    def send_push_token(self, request_data: dict, request_user: Menu):
+        token_send_request_serializer = TokenRequestSerializer(data=request_data)
+        token_send_request_serializer.is_valid(raise_exception=True)
+        token_data = token_send_request_serializer.validated_data
+
+        device = Device(
+            device_token=token_data.get('push_token'),
+            member=request_user,
+        )
+        self._push_repository.save_device(device)
+    
+    def delete_device(self, request_data, request_user):
+        token_send_request_serializer = TokenRequestSerializer(data=request_data)
+        token_send_request_serializer.is_valid(raise_exception=True)
+        token_data = token_send_request_serializer.validated_data
+
+        device: Device = self._push_repository.find_device_by_token_and_member(token_data.get('push_token'), request_user)
+
+        self._push_repository.delete_device(device)

--- a/push/services/push_services.py
+++ b/push/services/push_services.py
@@ -64,16 +64,13 @@ class PushService:
         return notification_data
     
     def make_multicast_message(self, notification_data: dict):
-        # 만약에 data가 없다면 해당 알림은 식단 알림이다. 따라서 data가 존재하지 않는다.
+        multicast_extra_data = {
+            "tokens": notification_data.get('tokens')
+        }
+        # 만약에 data 있다면 message에 포함시킨다.
         if notification_data.get('data'):
-            multicast_extra_data = {
-                "data": notification_data.get('data'),
-                "tokens": notification_data.get('tokens')
-            }
-        else:
-            multicast_extra_data = {
-                "tokens": notification_data.get('tokens')
-            }
+            multicast_extra_data['data'] = notification_data.get('data')
+          
         # 알림 필수 정보를 삽입한다.
         message = messaging.MulticastMessage(
             notification = messaging.Notification(

--- a/push/services/push_services.py
+++ b/push/services/push_services.py
@@ -18,7 +18,7 @@ class PushService:
         menu_string_set, title = self._get_menu_data_set_and_message_title(timezone)
         notification_data = {
             'member_ids': member_ids,
-            "title": title,
+            "title": f"🐿️ 오늘의 돔토리 {title} 메뉴에요. 🍽️",
             "body": menu_string_set,
             "tokens": valid_device_tokens
         }
@@ -99,7 +99,7 @@ class PushService:
             'body': notification_data.get('body'),
             'isChecked': 0
         }
-        # 만약 데이터가 있다면(식단 정보가 아니면) data에 있는 정보들을 item에 추가시킨다.
+        # 만약 데이터가 있다면 data에 있는 정보들을 item에 추가시킨다.
         if notification_data.get('data'):
             data: dict = notification_data.get('data')
             for key, value in data.items():
@@ -108,7 +108,7 @@ class PushService:
         #batch_writer를 활용해 한번에 저장시킨다. 이 때 멤버 아이디도 추가한다.
         with table.batch_writer() as batch:
             for member_id in member_ids:
-                new_item = item.copy()  # create a new dictionary
+                new_item = item.copy()
                 new_item['memberId'] = member_id
                 batch.put_item(Item=new_item)
 

--- a/push/services/push_services.py
+++ b/push/services/push_services.py
@@ -1,80 +1,116 @@
-from push.serializers import TokenRequestSerializer
 from push.domains import PushRepository
 from board.repositories import BoardRepository
 from firebase_admin import messaging
 from datetime import datetime
 from django.shortcuts import get_list_or_404
 from menu.models import Menu
-from push.domains.device import Device
+from utils.connect_dynamodb import get_dynamodb_table
 
 class PushService:
     def __init__(self, push_repository: PushRepository, board_repository: BoardRepository):
         self._push_repository = push_repository
         self._board_repository = board_repository
-
-    def send_push_token(self, request_data: dict, request_user: Menu):
-        token_send_request_serializer = TokenRequestSerializer(data=request_data)
-        token_send_request_serializer.is_valid(raise_exception=True)
-        token_data = token_send_request_serializer.validated_data
-
-        device = Device(
-            device_token=token_data.get('push_token'),
-            member=request_user,
-        )
-        self._push_repository.save_device(device)
     
-    def make_menu_push_notification_message(self, event, timezone: str):
+    def make_menu_push_notification_data(self, event, timezone: str):
         valid_devices = self._push_repository.find_all_devices()
+        member_ids = {valid_device.member_id for valid_device in valid_devices}
         valid_device_tokens = [valid_device.device_token for valid_device in valid_devices]
         menu_string_set, title = self._get_menu_data_set_and_message_title(timezone)
-
-        message = messaging.MulticastMessage(
-            notification = messaging.Notification(
-            title=f'🐿️ 돔토리 {title}식단 알리미',
-            body=menu_string_set
-        ),
-            tokens=valid_device_tokens,
-        )
-        return message
-    
-    def delete_device(self, request_data, request_user):
-        token_send_request_serializer = TokenRequestSerializer(data=request_data)
-        token_send_request_serializer.is_valid(raise_exception=True)
-        token_data = token_send_request_serializer.validated_data
-
-        device: Device = self._push_repository.find_device_by_token_and_member(token_data.get('push_token'), request_user)
-
-        self._push_repository.delete_device(device)
+        notification_data = {
+            'member_ids': member_ids,
+            "title": title,
+            "body": menu_string_set,
+            "tokens": valid_device_tokens
+        }
+        return notification_data 
 
     def send_push_notification(self, message):
         response = messaging.send_multicast(message)
         return response
 
-    def make_comment_push_notification_message(
+    def make_comment_push_notification_data(
             self,
             event: str,
             comment_id: int
         ):
+        # 코멘트를 post와 parent를 조인해서 가져온다.
         comment = self._board_repository.find_comment_by_comment_id_with_post_and_parent(comment_id)
-        if not comment.parent: # 댓글일 때
-            device_tokens = self._find_device_tokens_when_comment(comment)
+        if not comment.parent: # 댓글일 때. 이 if, else 문에서 device_tokens과 member_ids를 만든다.
+            device_tokens, devices = self._get_device_tokens_and_devices_when_comment(comment)
+
+            # 가져온 devices들로 member_id를 뽑아낸다. 본인의 글에 댓글을 달 경우 devices는 None으로 오게 된다.
+            if devices:
+                member_ids = {device.member_id for device in devices}
+            else:
+                member_ids = None
+
             title = f'🐿️ \'{comment.post.title}\'글에 새로운 댓글이 달렸어요.'
         else: # 대댓글일 때
-            device_tokens = self._find_device_tokens_when_reply(comment)
+            device_tokens, member_ids = self._get_device_tokens_and_member_ids_when_reply(comment)
             title = f'🐿️ \'{comment.post.title}\'글에 새로운 대댓글이 달렸어요.'
-
-        message = messaging.MulticastMessage(
-            notification = messaging.Notification(
-            title=title,
-            body=comment.body
-        ),
+        
+        # 댓글 대댓글의 푸시 알림은 이동을 위한 postId와 boardId가 필요하다.
         data={
             'postId': str(comment.post_id),
             'boardId': str(comment.post.board_id)
-        },
-        tokens=device_tokens,
+        }
+        notification_data = {
+            "member_ids": member_ids,
+            "title": title,
+            "body": comment.body,
+            "tokens": device_tokens,
+            "data": data
+        }
+        return notification_data
+    
+    def make_multicast_message(self, notification_data: dict):
+        # 만약에 data가 없다면 해당 알림은 식단 알림이다. 따라서 data가 존재하지 않는다.
+        if notification_data.get('data'):
+            multicast_extra_data = {
+                "data": notification_data.get('data'),
+                "tokens": notification_data.get('tokens')
+            }
+        else:
+            multicast_extra_data = {
+                "tokens": notification_data.get('tokens')
+            }
+        # 알림 필수 정보를 삽입한다.
+        message = messaging.MulticastMessage(
+            notification = messaging.Notification(
+            title=notification_data.get('title'),
+            body=notification_data.get('body')
+        ),
+        **multicast_extra_data # 그 외 multicast 부가 정보를 언패킹한다.
         )
         return message
+
+    def save_push_notifications(self, notification_data: dict):
+        now = datetime.now()
+        table = get_dynamodb_table('domtory')
+
+        # member_ids가 존재하지 않으면, 저장할 필요가 없다. 본인 글에 본인이 댓글, 대댓글을 단 경우이다.
+        member_ids: set | None = notification_data.get('member_ids')
+        if not member_ids:
+            return
+        
+        item = {
+            'pushedAt': str(now),
+            'title': notification_data.get('title'),
+            'body': notification_data.get('body'),
+            'isChecked': 0
+        }
+        # 만약 데이터가 있다면(식단 정보가 아니면) data에 있는 정보들을 item에 추가시킨다.
+        if notification_data.get('data'):
+            data: dict = notification_data.get('data')
+            for key, value in data.items():
+                item[key] = value
+
+        #batch_writer를 활용해 한번에 저장시킨다. 이 때 멤버 아이디도 추가한다.
+        with table.batch_writer() as batch:
+            for member_id in member_ids:
+                new_item = item.copy()  # create a new dictionary
+                new_item['memberId'] = member_id
+                batch.put_item(Item=new_item)
 
     def _make_today_date_code(self):
         now = datetime.now()
@@ -88,7 +124,7 @@ class PushService:
             "dinner": "저녁"
         }
         date_code: str = self._make_today_date_code()
-        target_table_name = timezone + 's'
+        target_table_name = timezone
         menu: list[Menu] = get_list_or_404(Menu.objects.prefetch_related(target_table_name), date_code=date_code)
         menu_set = getattr(menu[0], target_table_name).all()
 
@@ -103,14 +139,14 @@ class PushService:
         title = title_mapping.get(timezone)
         return menu_string_set, title
     
-    def _find_device_tokens_when_comment(self, comment):
+    def _get_device_tokens_and_devices_when_comment(self, comment):
         member_id = comment.post.member_id
         devices = self._push_repository.find_devices_by_member_id(member_id)
         if comment.member_id == comment.post.member_id:
-            return []
-        return list(set(device.device_token for device in devices))
+            return [], None
+        return list(set(device.device_token for device in devices)), set(devices)
     
-    def _find_device_tokens_when_reply(self, comment):
+    def _get_device_tokens_and_member_ids_when_reply(self, comment):
         same_parent_comments = self._board_repository.find_comments_by_parent_with_member(comment.parent)
         member_ids = [
             same_parent_comment.member_id
@@ -123,4 +159,4 @@ class PushService:
             if member_id != comment.member_id
         ] # 본인의 댓글에 대댓글을 달거나 본인의 글에 있는 댓글에 대댓글을 달 때를 알림이 가지 않게
         devices = self._push_repository.find_devices_by_member_ids(member_ids)
-        return list(set(device.device_token for device in devices))
+        return list(set(device.device_token for device in devices)), set(member_ids)

--- a/push/services/push_services.py
+++ b/push/services/push_services.py
@@ -129,13 +129,13 @@ class PushService:
         push_check_request_serializer.is_valid(raise_exception=True)
         push_data = push_check_request_serializer.validated_data
         
-        response = self._table.update_item(
+        self._table.update_item(
             Key={"memberId": push_data.get('member_id'), "pushedAt": push_data.get('pushed_at')},
             UpdateExpression="set isChecked=:c",
             ExpressionAttributeValues={":c": True},
             ReturnValues="UPDATED_NEW",
         )
-        print(response)
+
 
     def _make_today_date_code(self):
         now = datetime.now()

--- a/push/tasks.py
+++ b/push/tasks.py
@@ -17,12 +17,18 @@ def send_push_notification_handler(
     ):
     try:
         push_service = PushContainer.push_service()
-        message = None
-        if event == 'menu-scheule-event':
-            message = push_service.make_menu_push_notification_message(event, timezone)
-        elif event == 'comment-notification-event':
-            message = push_service.make_comment_push_notification_message(event, comment_id)
+        notification_data = None
+        
+        # 받은 이벤트를 기반으로 분기해서 notification data를 만든다.  
+        if event == 'menu-scheule-event': # 메뉴 알림일 때
+            notification_data = push_service.make_menu_push_notification_data(event, timezone)
+        elif event == 'comment-notification-event': # 댓글 알림일 때
+            notification_data = push_service.make_comment_push_notification_data(event, comment_id)
+
+        # notification data를 기반으로 multicast_message를 만든다.
+        message = push_service.make_multicast_message(notification_data)
         response = push_service.send_push_notification(message)
+        push_service.save_push_notifications(notification_data)
 
         for idx, resp in enumerate(response.responses):
             if resp.success:
@@ -30,4 +36,4 @@ def send_push_notification_handler(
             else:
                 raise FCMSendException
     except Exception as e:
-        logging.error(f'send_menu_push_notification_beat 에러: {e}')
+        logging.error(f'send_push_notification_handler 에러: {e}')

--- a/push/tasks.py
+++ b/push/tasks.py
@@ -28,7 +28,10 @@ def send_push_notification_handler(
         # notification data를 기반으로 multicast_message를 만든다.
         message = push_service.make_multicast_message(notification_data)
         response = push_service.send_push_notification(message)
-        push_service.save_push_notifications(notification_data)
+
+        # 식단 알림은 저장하지 않는다.
+        if event != 'menu-scheule-event':
+            push_service.save_push_notifications(notification_data)
 
         for idx, resp in enumerate(response.responses):
             if resp.success:

--- a/push/urls.py
+++ b/push/urls.py
@@ -1,10 +1,16 @@
 from django.urls import path
-from push.views import PushView, PushSendView, TokenInvalidView
+from push.views import (
+    PushView,
+    PushSendView, 
+    TokenInvalidView,
+    PushListGetVIew,
+)
 
 app_name = 'push'
 
 urlpatterns = [
     path('token/', PushView.as_view()),
     path('send/', PushSendView.as_view()),
-    path('token/invalid/', TokenInvalidView.as_view())
+    path('token/invalid/', TokenInvalidView.as_view()),
+    path('list/', PushListGetVIew.as_view()),
 ]

--- a/push/urls.py
+++ b/push/urls.py
@@ -4,6 +4,7 @@ from push.views import (
     PushSendView, 
     TokenInvalidView,
     PushListGetVIew,
+    PushCheckView,
 )
 
 app_name = 'push'
@@ -13,4 +14,5 @@ urlpatterns = [
     path('send/', PushSendView.as_view()),
     path('token/invalid/', TokenInvalidView.as_view()),
     path('list/', PushListGetVIew.as_view()),
+    path('check/', PushCheckView.as_view()),
 ]

--- a/push/views/__init__.py
+++ b/push/views/__init__.py
@@ -2,3 +2,4 @@ from .push_views import PushView
 from .push_send_view import PushSendView
 from .token_invalid_view import TokenInvalidView
 from .push_list_get_view import PushListGetVIew
+from .push_check_view import PushCheckView

--- a/push/views/__init__.py
+++ b/push/views/__init__.py
@@ -1,3 +1,4 @@
 from .push_views import PushView
 from .push_send_view import PushSendView
 from .token_invalid_view import TokenInvalidView
+from .push_list_get_view import PushListGetVIew

--- a/push/views/push_check_view.py
+++ b/push/views/push_check_view.py
@@ -29,5 +29,5 @@ class PushCheckView(APIView):
         """
         푸시 알림 기록을 본 직후 불러와서 isChecked를 True로 바꿔주는 api 입니다.
         """
-        response = self._push_service.check_push_notification(request.data)
-        return Response(response, status=status.HTTP_200_OK)
+        self._push_service.check_push_notification(request.data)
+        return Response(status=status.HTTP_200_OK)

--- a/push/views/push_check_view.py
+++ b/push/views/push_check_view.py
@@ -1,0 +1,33 @@
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.views import APIView
+from push.containers import PushContainer
+from drf_yasg.utils import swagger_auto_schema
+from push.serializers import PushCheckRequestSerialzier
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework.permissions import IsAuthenticated
+from drf_yasg import openapi
+
+authorization_header = openapi.Parameter(
+    'Authorization', 
+    openapi.IN_HEADER, 
+    description="Bearer <token>", 
+    type=openapi.TYPE_STRING,
+    required=True
+)
+
+class PushCheckView(APIView):
+    authentication_classes = [JWTAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._push_service = PushContainer.push_service()
+
+    @swagger_auto_schema(manual_parameters=[authorization_header], request_body=PushCheckRequestSerialzier,responses={"200": ""})
+    def put(self, request):
+        """
+        푸시 알림 기록을 본 직후 불러와서 isChecked를 True로 바꿔주는 api 입니다.
+        """
+        response = self._push_service.check_push_notification(request.data)
+        return Response(response, status=status.HTTP_200_OK)

--- a/push/views/push_list_get_view.py
+++ b/push/views/push_list_get_view.py
@@ -1,0 +1,33 @@
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.views import APIView
+from push.containers import PushContainer
+from drf_yasg.utils import swagger_auto_schema
+from push.serializers import PushListResponseSerializer
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework.permissions import IsAuthenticated
+from drf_yasg import openapi
+
+authorization_header = openapi.Parameter(
+    'Authorization', 
+    openapi.IN_HEADER, 
+    description="Bearer <token>", 
+    type=openapi.TYPE_STRING,
+    required=True
+)
+
+class PushListGetVIew(APIView):
+    authentication_classes = [JWTAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._push_service = PushContainer.push_service()
+
+    @swagger_auto_schema(manual_parameters=[authorization_header], responses={"200": PushListResponseSerializer})
+    def get(self, request):
+        """
+        푸시 알람 기록 리스트를 가져오는 api 입니다. 총 20개 불러옵니다.
+        """
+        response = self._push_service.get_push_list(request.user)
+        return Response(response, status=status.HTTP_200_OK)

--- a/push/views/push_views.py
+++ b/push/views/push_views.py
@@ -13,12 +13,12 @@ class PushView(APIView):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._push_service = PushContainer.push_service()
+        self._device_service = PushContainer.device_service()
 
     @swagger_auto_schema(request_body=TokenRequestSerializer, responses={"200": ""})
     def post(self, request):
         """
         FCM 푸시 토큰을 서버로 보내는 API 입니다.
         """
-        self._push_service.send_push_token(request.data, request.user)
+        self._device_service.send_push_token(request.data, request.user)
         return Response(status=status.HTTP_200_OK)

--- a/push/views/token_invalid_view.py
+++ b/push/views/token_invalid_view.py
@@ -13,12 +13,12 @@ class TokenInvalidView(APIView):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._push_service = PushContainer.push_service()
+        self._device_service = PushContainer.device_service()
 
     @swagger_auto_schema(request_body=TokenRequestSerializer, responses={"204": ""})
     def post(self, request):
         """
         토큰 삭제 API
         """
-        self._push_service.delete_device(request.data, request.user)
+        self._device_service.delete_device(request.data, request.user)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/utils/connect_dynamodb.py
+++ b/utils/connect_dynamodb.py
@@ -1,14 +1,14 @@
 from decouple import config
 import boto3
 
-def get_dynamodb_table():
-    AWS_ACCCESS_KEY=config('AWS_ACCCESS_KEY')
+def get_dynamodb_table(table_name):
+    AWS_ACCESS_KEY=config('AWS_ACCESS_KEY')
     AWS_SECRET_ACCESS_KEY=config('AWS_SECRET_ACCESS_KEY')
     
     dynamodb = boto3.resource(
         'dynamodb', region_name='ap-northeast-2',
-        aws_access_key_id=AWS_ACCCESS_KEY,
+        aws_access_key_id=AWS_ACCESS_KEY,
         aws_secret_access_key=AWS_SECRET_ACCESS_KEY
     )
-    return dynamodb.Table('clclcafe')
+    return dynamodb.Table(table_name)
     


### PR DESCRIPTION
### 🌟이슈 번호
- #13 
### 작업한 내용
- Device관련 로직 `DeviceService` 분리
- 알림 정보를 만들고 메시지를 만드는 로직 분리(`make_~~~_message` 에서 `make_~~notification_data`와 `make_multicast_message`으로 분리)
- 알림을 DynanoDB로 저장하는 기능 추가 `save_push_notifications`
- push get list api 추가
```json
[
    {
        "memberId": 750,
        "title": "🐿️ '푸시'글에 새로운 댓글이 달렸어요.",
        "body": "다시.다시.다시.다시.",
        "pushedAt": "02/20 21:43",
        "boardId": 1,
        "postId": 160,
        "isChecked": false
    },
             ....
    {
        "memberId": 750,
        "title": "🐿️ '푸시'글에 새로운 댓글이 달렸어요.",
        "body": "다시.다시.다시.",
        "pushedAt": "02/20 19:07",
        "boardId": 1,
        "postId": 160,
        "isChecked": false
    }
]
```
- check push api 추가. 사용자가 푸시 알림을 열람하면 `isChecked`를 True로 변환
- push 알림 delete 추가. dyanmoDB에서 삭제.

## DynamoDB를 쓴 이유
- DynamoDB는 AWS의 대표적인 Nosql 데이터베이스이고, 키 값으로 저장됩니다.
- RDB의 조인 능력 같은 것은 없지만 키-값으로 빠른 조회, 업데이트, 삭제가 가능합니다.
- 따라서 주로 채팅 내용이나 알림 목록 같은 빠른 반응이 필요한 기능에 들어갑니다.
- 자세한건 구글링 ㄱㄱ