### PR TITLE
[REFACTOR] 게시판 푸시 알림 추상화

### DIFF
--- a/board/views/council_CRUD_views.py
+++ b/board/views/council_CRUD_views.py
@@ -11,7 +11,7 @@ from PIL import Image
 from io import BytesIO
 from utils.s3 import S3Connect
 import uuid
-
+from push.tasks import send_push_notification_handler
 
 class CouncilPostCreateView(APIView):
     """
@@ -25,6 +25,7 @@ class CouncilPostCreateView(APIView):
         serializer = PostRequestSerializer(data = request.data)
         if serializer.is_valid():
             post = serializer.save(member = request.user, board = board)
+            send_push_notification_handler.delay('post-notification-event', post_id=post.id)
             if 'images' not in request.data:
                 return Response(PostResponseSerializer(post, context = {'request' : request}).data, status = status.HTTP_201_CREATED)
 

--- a/board/views/post_CRUD_views.py
+++ b/board/views/post_CRUD_views.py
@@ -31,7 +31,7 @@ class PostCreateView(APIView):
         if serializer.is_valid():
             post = serializer.save(member = request.user, board = board)
             if post.board_id == 4:
-                send_push_notification_handler.delay('lightning-post-notification-event', post_id=post.id)
+                send_push_notification_handler.delay('post-notification-event', post_id=post.id)
             if 'images' not in request.data:
                 return Response(PostResponseSerializer(post, context = {'request' : request}).data, status = status.HTTP_201_CREATED)
 

--- a/push/services/push_services.py
+++ b/push/services/push_services.py
@@ -51,13 +51,16 @@ class PushService:
         }
         return self._wrapping_notification_data(member_ids, title, comment.body, device_tokens, data)
 
-    def make_lightning_post_push_notification_data(self, event: str, post_id: int):
+    def make_post_push_notification_data(self, event: str, post_id: int):
         post: Post = self._board_repository.find_post_by_id(post_id)
         valid_devices = self._push_repository.find_all_devices()
         valid_device_tokens = [valid_device.device_token for valid_device in valid_devices]
         member_ids = {valid_device.member_id for valid_device in valid_devices}
-
-        title = f'🐿️ ⚡️새로운 번개모임⚡️이 생겼어요!'
+        title_dict = {
+            4 : f'🐿️ ⚡️새로운 번개모임⚡️이 생겼어요!',
+            6 : f'🐿️ 새로운 자율회 공지사항이에요! 📢'
+        }
+        title = title_dict.get(post.board_id)
         data={
             'postId': str(post.id),
             'boardId': str(post.board_id)

--- a/push/tasks.py
+++ b/push/tasks.py
@@ -14,7 +14,7 @@ def send_push_notification_handler(
         event: str,
         timezone: str=None,
         comment_id: int=None,
-        post_id: int=None,
+        post_id: int=None
     ):
     try:
         push_service = PushContainer.push_service()
@@ -25,8 +25,8 @@ def send_push_notification_handler(
             notification_data = push_service.make_menu_push_notification_data(event, timezone)
         elif event == 'comment-notification-event': # 댓글 알림일 때
             notification_data = push_service.make_comment_push_notification_data(event, comment_id)
-        elif event == 'lightning-post-notification-event':
-            notification_data = push_service.make_lightning_post_push_notification_data(event, post_id)
+        elif event == 'post-notification-event':
+            notification_data = push_service.make_post_push_notification_data(event, post_id)
             
         # 식단 알림은 저장하지 않는다.
         if event != 'menu-scheule-event':

--- a/server/settings/prod.py
+++ b/server/settings/prod.py
@@ -17,6 +17,9 @@ DATABASES = {
         'PASSWORD': config('DB_PASSWORD'),
         'HOST': config('DB_HOST'),
         'PORT': config('DB_PORT'),
+        'OPTIONS': {
+            'charset': 'utf8mb4',
+        }
     }
 }
 


### PR DESCRIPTION
### 🌟이슈 번호
- #13 
### 작업한 내용
- 번개 게시판만 알림이 가는 것이 아니라, 설정한 board에 따라서 알림이 가도록 변경
- task를 추상화 시켰습니다. `post` 로 추상화 시켜서 이후에 다른 게시판 알림에도 유연하게 대응할 수 있도록 변경했습니다.